### PR TITLE
fix: resolve Next.js example test failures by aliasing evmauth to source

### DIFF
--- a/examples/nextjs/vitest.config.ts
+++ b/examples/nextjs/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     resolve: {
         alias: {
             '@': resolve(__dirname, './src'),
+            'evmauth': resolve(__dirname, '../../src/index.ts'),
         },
     },
 });


### PR DESCRIPTION
## Description

This PR fixes an issue where Next.js example tests would fail when run without first building the evmauth package. The root cause was that test files were importing from 'evmauth', which according to the package.json points to dist/index.js - a file that doesn't exist until after running pnpm build.

The fix adds a Vitest path alias that maps 'evmauth' imports directly to the TypeScript source code during testing. This allows developers to clone the repo and immediately run tests without needing to build first, improving the developer experience.

Fixes #14

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other, please describe:

Tested by:
  1. Running pnpm test in the Next.js example directory without a built dist folder
  2. Verifying all 84 tests pass successfully
  3. Temporarily removing the fix to confirm tests would fail without it (though some tests pass due to mocking)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Additional context:

This change improves the developer experience for contributors by removing the need to understand the build dependency between the main package and examples. The approach follows common monorepo patterns where development-time imports reference source code directly while production builds use the compiled artifacts.